### PR TITLE
Get Login Screen Working & Adding Mangling

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -218,7 +218,7 @@ module.exports = function (grunt) {
     },
     uglify: {
       options: {
-        mangle: false 
+        mangle: true 
       },
       dist: {
         files: [
@@ -422,9 +422,9 @@ module.exports = function (grunt) {
     'useminPrepare',
     'postcss',
     'ngtemplates:dist',
+    'ngAnnotate',
     'concat:dist',
     'concat:generated',
-    'ngAnnotate',
     'copy:dist',
     'cdnify',
     'cssmin',

--- a/client/app/common/services/loginManager.service.js
+++ b/client/app/common/services/loginManager.service.js
@@ -39,10 +39,10 @@ function loginManager($q, $http, $state) {
 	function _login(username, password) {
 		var deferred = $q.defer();
 
-		$http.post('api/login', {username: username, password: password})
-			.success(function(token) {
-				service.token = token;
-				deferred.resolve(token);
+		$http.post('api/login', {email: username, password: password})
+			.success(function(data) {
+				service.token = data.token;
+				deferred.resolve(data.token);
 			})
 			.error(function(data, status) {
 				deferred.reject(status);

--- a/client/app/dashboard/dashboard.html
+++ b/client/app/dashboard/dashboard.html
@@ -2,6 +2,7 @@
 
 <!-- Content Wrapper. Contains page content -->
 <div class="content-wrapper" style="overflow:hidden">
+  Dashboard View
   <div ui-view=""></div>
 </div>
 <!-- /content-wrapper -->

--- a/client/app/dashboard/summary/summary.html
+++ b/client/app/dashboard/summary/summary.html
@@ -1,4 +1,4 @@
 
-<b> Hello There </b>
+<b> Summary View </b>
 
 

--- a/src/handlers/session/login.rs
+++ b/src/handlers/session/login.rs
@@ -9,6 +9,7 @@ pub struct Login;
 /// Creates a new user with attributes specified in the body of the request
 impl Handler for Login {
     fn handle(&self, req: &mut Request) -> IronResult<Response> {
+        // TODO: Wrap in result, in scenario where neccessary keys don't exist in the body
         let params = get_params(req);
 
         let token = authenticate(params.0, params.1.password_hash, params.1.id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         .put("/api/credits/:id", handlers::credit::Update)
         .post("api/credits/", handlers::credit::Create)
         .delete("api/credits/:id", handlers::credit::Delete)
-        .get("api/users/:id", handlers::user::Show)
+        .get("api/user", handlers::user::Show)
         .post("api/users/", handlers::user::Create)
         .post("api/login", handlers::session::Login);
 


### PR DESCRIPTION
### Description
This PR is responsible for getting the client side login screen working properly with the authentication on the backend. It ensures that when a user attempts to login, with valid credentials, they are able to get to the dashboard. 

### Changes
- Updated backend `GET /api/users/:id` to `GET /api/user` for fetching of a user via their token
- Updating the params sent from the client `login` method from`username` to `email` to properly correspond with the backend's expectations
- Turned on uglify's mangle option, and moved `ngAnnotate` before `concat` to get properly mangling working