### PR TITLE
Adding Grunt-Rust Task for building the Rust App

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,12 +9,12 @@ module.exports = function (grunt) {
     cdnify: 'grunt-google-cdn',
     protractor: 'grunt-protractor-runner',
     buildcontrol: 'grunt-build-control',
+    rust: 'tasks/rust.js',
   });
 
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
 
-  //grunt.loadTasks("./tasks"); // TODO: Add rust build task
   // Define the configuration for all the tasks
   grunt.initConfig({
 
@@ -24,6 +24,12 @@ module.exports = function (grunt) {
       // configurable paths
       client: require('./bower.json').appPath || 'client',
       dist: 'dist'
+    },
+    rust: {
+      options: {
+        verbose: true,
+      },
+      build: {},
     },
     watch: {
       babel: {
@@ -430,7 +436,8 @@ module.exports = function (grunt) {
     'cssmin',
     'uglify:dist',
     'filerev',
-    'usemin'
+    'usemin',
+    'rust:build',
   ]);
 
   grunt.registerTask('default', [

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "express-session": "^1.11.3",
     "karma": "^0.13.16",
     "kerberos": "0.0.17",
-    "lodash": "^3.10.1",
+    "lodash": "^4.0.0",
     "lusca": "^1.3.0",
     "method-override": "^2.3.5",
     "mocha": "^2.3.4",

--- a/tasks/optionsBuilder.js
+++ b/tasks/optionsBuilder.js
@@ -1,0 +1,101 @@
+var _ = require('lodash');
+
+module.exports = function optionsBuilder(target, config) {
+  if (!_.includes(['build', 'run', 'test'], target)) {
+    grunt.fatal('Invalid option sent to rust: ' + cargoProgram);
+  }
+
+  var options = [target];
+
+  _.concat(options, getGeneralOptions(config));
+  _.concat(options, getTargetSpecificOptions(target, config));
+
+  return options;
+}
+
+function getGeneralOptions(config) {
+  var generalOptions = [];
+
+  if (config.bin) {
+    generalOptions.push('--bin ' + bin);
+  }
+
+  if (config.jobs > 0) {
+    generalOptions.push('--jobs ' + config.jobs);
+  }
+ 
+  if (config.release) {
+    generalOptions.push('--release');
+  }
+
+  if (config.features && config.features.length > 0) {
+    var features = '--features ';
+    _.forEach(config.features, function(feature) {
+      features += (feature + ' ');
+    });
+    generalOptions.push(features);
+  }
+
+  if (config.noDefaultFeatures) {
+    generalOptions.push('--no-default-features');
+  }
+  
+  if (config.target) {
+    generalOptions.push('--target ' + config.target); 
+  }
+
+  if (config.manifestPath) {
+    generalOptions.push('--manifest-path ' + config.manifestPath);
+  }
+
+  return generalOptions;
+}
+
+function getTargetSpecificOptions(target, config) {
+  if (target == 'run') {
+    return getRunTargetOptions(config);
+  }
+  else if (target == 'build') {
+    return getBuildTargetOptions(config);
+  }
+  else {
+    return getTestTargetOptions(config);
+  }
+}
+
+function getRunTargetOptions(config) {
+  return [];
+}
+
+function getBuildTargetOptions(config) {
+  var buildOptions = [];
+
+  if (config.lib) {
+    buildOptions.push('--lib'); 
+  }
+
+
+  return buildOptions; 
+}
+
+function getTestTargetOptions(config) {
+  var testOptions = []; 
+
+  if (config.lib) {
+    testOptions.push('--lib'); 
+  }
+
+  if (config.doc) {
+    testOptions.push('--doc');
+  }
+
+  if (config.test) {
+    testOptions.push('--test ' + config.test);
+  }
+  
+  if (config.noRun) {
+    testOptions.push('--no-run');
+  }
+
+  return testOptions;
+}

--- a/tasks/rust.js
+++ b/tasks/rust.js
@@ -1,0 +1,33 @@
+var spawn = require('child_process').spawn;
+var _ = require('lodash');
+var optionsBuilder = require('./optionsBuilder.js');
+
+module.exports = function (grunt) {
+  grunt.registerMultiTask('rust', 'Building rust project', function () {
+    var done = this.async();
+    var cargoProgram = this.target;
+    
+   var options = optionsBuilder(cargoProgram, this.data);
+
+    var cargo = spawn(
+      'cargo', options 
+    );
+
+    if (this.options().verbose) {
+      cargo.stdout.on('data', function (data) {
+        grunt.log.write(data.toString()); 
+      });
+
+      cargo.stderr.on('data', function (data) {
+        grunt.log.write(data.toString());
+      });
+    }
+
+    cargo.on('close', function () {
+      grunt.log.writeln('Cargo finished');
+      done();
+    });
+
+  });
+}
+


### PR DESCRIPTION
### Description
Adding a grunt task that gives us the ability to `test`, `build`, or `run` the rust application.

### Changes
- Added a `tasks` folder to put the new `rust` grunt task.
- Edited the `Gruntfile` to include the `build` option of the `rust` task in grunt build task
- Updated to `lodash` version `4.0.0`