### PR TITLE
Add 'paid_date' to Update and Create Credit Endpoints

### DIFF
--- a/client/app/dashboard/dashboard.controller.js
+++ b/client/app/dashboard/dashboard.controller.js
@@ -3,17 +3,13 @@
 angular.module('paymentProcessor')
   .controller('DashboardCtrl', dashboardCtrl);
 
-function dashboardCtrl($scope, $state, loginManager) {
-  loginManager.redirectIfNotLoggedIn();
-
-  /*jshint validthis: true */
-  var viewModel = this;
+// TODO: Determine if this intermediary view is necessary for our workflow
+function dashboardCtrl() {
 
   /** Controller Variables **/
-  viewModel.currentUser = 'User not logged in';
+
 
   /** Controller Functions **/
-  viewModel.goTo = _goTo;
 
 
   _initController();
@@ -21,12 +17,5 @@ function dashboardCtrl($scope, $state, loginManager) {
   /******** Implementation *******/
 
   function _initController() {
-    loginManager.getUser().then(function(username) {
-      viewModel.currentUser = username.fullname;
-    });
-  }
-
-  function _goTo(goTo) {
-    $state.go(goTo);
   }
 }

--- a/client/app/dashboard/dashboard.html
+++ b/client/app/dashboard/dashboard.html
@@ -2,7 +2,7 @@
 
 <!-- Content Wrapper. Contains page content -->
 <div class="content-wrapper" style="overflow:hidden">
-  Dashboard View
+  <!-- TODO: Determine if this intermediary view is neccessary -->
   <div ui-view=""></div>
 </div>
 <!-- /content-wrapper -->

--- a/client/components/navbar/navbar.controller.js
+++ b/client/components/navbar/navbar.controller.js
@@ -1,15 +1,33 @@
 'use strict';
 
 function navbarController() {
-  //start-non-standard
-  var menu = [{
-    'title': 'Home',
-    'state': 'main'
-  }];
+  /*jshint validthis: true */
+  var viewModel = this;
 
-  var isCollapsed = true;
-  //end-non-standard
+  /** Controller Variables **/
+  viewModel.isCollapsed = null;
+  viewModel.loginError = [];
 
+  /** Controller Functions **/
+
+
+  _initController();
+  
+  /****** Implementation ******/
+
+  function _initController() {
+    viewModel.isCollapsed = false;
+    viewModel.menu = [{
+      'title': 'Overview',
+      'state': 'dashboard.summary'
+    }, {
+      'title': 'Credits',
+      'state': 'dashboard.credits'
+    }, {
+      'title': 'Debts',
+      'state': 'dashboard.debts'
+    }];
+  }
 }
 
 angular.module('paymentProcessor')

--- a/client/components/navbar/navbar.html
+++ b/client/components/navbar/navbar.html
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a href="/" class="navbar-brand">web-api</a>
+      <a href="/" class="navbar-brand">Payment Processor</a>
     </div>
     <div collapse="nav.isCollapsed" class="navbar-collapse collapse" id="navbar-main">
       <ul class="nav navbar-nav">

--- a/src/handlers/credit/create.rs
+++ b/src/handlers/credit/create.rs
@@ -4,7 +4,7 @@ use iron::{Handler, headers, status};
 use diesel::types::structs::data_types::PgTimestamp;
 use rustc_serialize::json::{ToJson};
 use models::credit::{Credit, Createable};
-use services::{get_user_id, get_key_from_body};
+use services::{get_user_id, get_key_from_body, from_unix_to_postgres_datetime};
 use util::Orm;
 
 
@@ -24,14 +24,17 @@ impl Handler for Create {
     }
 }
 fn build_new_credit(req: &mut Request) -> Createable {
-    // TODO: Mke it so that you can specify a `paid date` as well
     let user_id = get_user_id(req);
     let amount = get_key_from_body::<i32>(req, "amount");
+    let paid_date = from_unix_to_postgres_datetime(
+        get_key_from_body::<i64>(req, "paid_date").unwrap()
+    );
     let created_date = PgTimestamp(Local::now().naive_local().timestamp() );
 
     Createable {
         user_id: user_id,
         amount: amount,
+        paid_date: Some(PgTimestamp(paid_date)),
         created_date: created_date
     }
 }

--- a/src/handlers/credit/update.rs
+++ b/src/handlers/credit/update.rs
@@ -1,8 +1,9 @@
 use iron::prelude::*;
 use iron::{Handler, headers, status};
+use diesel::types::structs::data_types::PgTimestamp;
 use rustc_serialize::json::{ToJson};
 use models::credit::{Credit, Alterable};
-use services::{get_user_id, get_route_id, get_key_from_body};
+use services::{get_user_id, get_route_id, get_key_from_body, from_unix_to_postgres_datetime};
 use util::Orm;
 
 pub struct Update;
@@ -22,13 +23,17 @@ impl Handler for Update {
     }
 }
 fn get_params(req: &mut Request) -> (i32, i32, Alterable) {
-    // TODO: Make it so that you can update `paid_date` as well
     let credit_id = get_route_id(req);
     let user_id = get_user_id(req);
 
     let amount = get_key_from_body::<i32>(req, "amount");
+    let paid_date = from_unix_to_postgres_datetime(
+        get_key_from_body::<i64>(req, "paid_date").unwrap()
+    );
+
     let updated_credit = Alterable {
-        amount: amount
+        amount: amount,
+        paid_date: Some(PgTimestamp(paid_date))
     };
 
     (credit_id, user_id, updated_credit)

--- a/src/models/credit.rs
+++ b/src/models/credit.rs
@@ -23,13 +23,13 @@ pub struct Credit {
 pub struct Createable {
     pub user_id: i32,
     pub amount: Option<i32>,
-    //pub paid_date: Option<PgTimestamp>,
+    pub paid_date: Option<PgTimestamp>,
     pub created_date: PgTimestamp
 }
 
 pub struct Alterable {
     pub amount: Option<i32>,
-    //pub paid_date: Option<PgTimestamp>,
+    pub paid_date: Option<PgTimestamp>,
 }
 
 impl ToJson for Credit {
@@ -88,11 +88,11 @@ impl Orm<Credit, Createable, Alterable> for Credit {
         let query = credits::table.filter(credits::id.eq(id))
             .filter(credits::user_id.eq(user_id));
 
-        // TODO: add ability to save paid date as well
         let result = update(query)
             .set(
                 (
-                    credits::amount.eq(obj.amount)
+                    credits::amount.eq(obj.amount),
+                    credits::paid_date.eq(obj.paid_date)
                 )
                 ).get_result::<Credit>(&conn)
             .expect(&format!("Unable to find post {}", id));

--- a/src/services/datetime_conversion.rs
+++ b/src/services/datetime_conversion.rs
@@ -11,3 +11,11 @@ pub fn from_postgres_to_unix_datetime(pg_timestamp: i64) -> i64 {
 
     seconds_since_pg_epoch + epoch_difference
 }
+
+/// Takes a unix datetime and converts it to a postgres datetime 
+pub fn from_unix_to_postgres_datetime(unix_timestamp: i64) -> i64 {
+    let epoch_difference = "2000-01-01T00:00:00".parse::<NaiveDateTime>().unwrap().timestamp();
+    let seconds_since_pg_epoch = unix_timestamp - epoch_difference;
+
+    seconds_since_pg_epoch * 1000000
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -18,6 +18,6 @@ pub use self::jwt::verify_token;
 pub use self::param_parser::get_user_id;
 pub use self::param_parser::get_route_id;
 pub use self::param_parser::get_key_from_body;
-pub use self::param_parser::get_key_from_uri_query;
 
 pub use self::datetime_conversion::from_postgres_to_unix_datetime;
+pub use self::datetime_conversion::from_unix_to_postgres_datetime;

--- a/src/services/param_parser.rs
+++ b/src/services/param_parser.rs
@@ -3,27 +3,23 @@ use router::{Router};
 use bodyparser::Json;
 use std::str::FromStr;
 use util::Auth;
-use std::collections::HashMap;
 
 /// Finds the user id stored in the request. The authentication middleware will 
 /// store it in the request's extentions. If no user_id is found, throw an error.
 // TODO: Throw error when no user_id is found
 pub fn get_user_id(req: &mut Request) -> i32 {
-    // TODO: Wrap in Result
     req.extensions.get::<Auth>().unwrap().to_owned()
 }
 
 /// Finds the id specified in the route of the request. For ex. a request that has a 
 /// route "api/credits/4" will produce an id of 4
 pub fn get_route_id(req: &mut Request) -> i32 {
-    // TODO: Wrap in Result
     req.extensions.get::<Router>().unwrap().find("id").unwrap_or("-1").parse::<i32>().unwrap()
 }
 
 /// Finds a particular key in the requests body. If the key does not exist in the 
 /// body, it returns None.
 pub fn get_key_from_body<T: FromStr>(req: &mut Request, key: &str) -> Option<T> {
-    // TODO: Wrap in Result
     let json_body = req.get::<Json>();
     match json_body {
         Ok(Some(json)) => {
@@ -35,13 +31,4 @@ pub fn get_key_from_body<T: FromStr>(req: &mut Request, key: &str) -> Option<T> 
         Ok(None) => None,
         Err(_) => None 
     }
-}
-
-/// Used only in the authentication service as of now. Will be removed once the
-/// authentication algorithm changes
-// TODO: Delete function
-pub fn get_key_from_uri_query<T: FromStr>(query: &HashMap<String, Vec<String>>, key: &'static str) -> Option<T> {
-    query.get(key).and_then(|vals| vals.get(0)).and_then(|val| {
-        val.parse::<T>().ok()
-    })
 }


### PR DESCRIPTION
### Description
Allow the `create` and `update` credit endpoints to receive, and properly save they `paid_date` key

### Changes
- Added method to services to allow conversion from unix datetime to postgres datetime
- Updated the credits model `Createable` and `Alterable` structs to include `paid_date`
- Updated `create` and `update` handlers to parse incoming `paid_date` from the body