### PR TITLE
Adding 'company_name', 'project_name' and 'payment_number' to models

### DIFF
--- a/client/app/common/models/credit.factory.js
+++ b/client/app/common/models/credit.factory.js
@@ -6,6 +6,8 @@ const MILLISECONDS_IN_MICROSECONDS = 1000;
 const DEFAULT_CREDIT = {
   id: null,
   userId: null,
+  projectName: '',
+  paymentNumber: 0,
   amount: 0,
   paidDate: '',
   createdDate: new Date()
@@ -21,6 +23,8 @@ function credit () {
       {
         id: creditData.id,
         userId: creditData.userId,
+        projectName: creditData.projectName,
+        paymentNumber: creditData.paymentNumber,
         amount: creditData.amount,
         paidDate: creditData.paidDate || new Date(creditData.paidDate * MILLISECONDS_IN_MICROSECONDS),
         createdDate: new Date(creditData.createdDate * MILLISECONDS_IN_MICROSECONDS)
@@ -33,6 +37,7 @@ function credit () {
     // All Business Logic Functions
     formatForServer: function () {
       return {
+
         amount: this.amount,
         paidDate: this.paidDate
       };

--- a/client/app/common/models/user.factory.js
+++ b/client/app/common/models/user.factory.js
@@ -7,6 +7,7 @@ const DEFAULT_USER = {
   id: null,
   email: '',
   admin: false,
+  companyName: '',
   firstName: '',
   lastName: '',
   createdDate: new Date()
@@ -23,6 +24,7 @@ function user () {
         id: userData.id,
         email: userData.email,
         admin: userData.admin,
+        companyName: userData.companyName,
         firstName: userData.firstName,
         lastName: userData.lastName,
         createdDate: new Date(userData.createdDate * MILLISECONDS_IN_MICROSECONDS)

--- a/client/app/dashboard/credits/credits.html
+++ b/client/app/dashboard/credits/credits.html
@@ -2,6 +2,8 @@
 <b> Credits </b>
 
 <div ng-repeat="credit in creditsCtrl.credits | orderBy:'paid_date':true">
+  <p>Project Name: {{credit.projectName}}</p>
+  <p>Payment Number: {{credit.paymentNumber}}</p>
   <p>Amount: {{credit.amount}}</p>
   <p>Paid Date: {{credit.paid_date}}</p>
 </div>

--- a/migrations/20160707162425_create_credits_table/up.sql
+++ b/migrations/20160707162425_create_credits_table/up.sql
@@ -1,7 +1,11 @@
 -- CREDITS table
+-- Should probably add a company table and foreign key
+-- to company on the credit, and remove company name from user tabl
 CREATE TABLE IF NOT EXISTS credits (
   id serial PRIMARY KEY,
   user_id integer,
+  project_name VARCHAR NOT NULL,
+  payment_number INTEGER NOT NULL,
   amount integer,
   paid_date timestamp without time zone,
   created_date timestamp without time zone NOT NULL 

--- a/migrations/20160710173023_StubData/up.sql
+++ b/migrations/20160710173023_StubData/up.sql
@@ -1,5 +1,5 @@
-INSERT INTO credits (user_id, amount, paid_date, created_date) VALUES (1, 100, now(), now());
-INSERT INTO credits (user_id, amount, paid_date, created_date) VALUES (1, 200, NULL, now());
-INSERT INTO credits (user_id, amount, paid_date, created_date) VALUES (1, 300, now(), now());
-INSERT INTO credits (user_id, amount, paid_date, created_date) VALUES (2, 400, now(), now());
-INSERT INTO credits (user_id, amount, paid_date, created_date) VALUES (2, 500, NULL, now());
+INSERT INTO credits (user_id, project_name, payment_number, amount, paid_date, created_date) VALUES (1,'Procore Gym', 100, 1, now(), now());
+INSERT INTO credits (user_id, project_name, payment_number, amount, paid_date, created_date) VALUES (1, 'Eiffle Tower', 200, 2, NULL, now());
+INSERT INTO credits (user_id, project_name, payment_number, amount, paid_date, created_date) VALUES (1, 'Chrystler Building', 3, 300, now(), now());
+INSERT INTO credits (user_id, project_name, payment_number, amount, paid_date, created_date) VALUES (2, 'Chick fil a', 2, 400, now(), now());
+INSERT INTO credits (user_id, project_name, payment_number, amount, paid_date, created_date) VALUES (2, 'My Mansion',4, 500, NULL, now());

--- a/migrations/20160719100836_AddUsersTable/up.sql
+++ b/migrations/20160719100836_AddUsersTable/up.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS users (
   id serial PRIMARY KEY,
   admin BOOL NOT NULL DEFAULT 'f',
   email VARCHAR NOT NULL,
+  company_name VARCHAR NOT NULL,
   first_name VARCHAR NOT NULL,
   last_name VARCHAR NOT NULL,
   password_hash VARCHAR NOT NULL,

--- a/migrations/20160719101159_AddDefaultUser/up.sql
+++ b/migrations/20160719101159_AddDefaultUser/up.sql
@@ -1,1 +1,1 @@
-INSERT INTO users (admin, email, first_name, last_name, password_hash, created_date) VALUES ('t', 'gabeharms', 'gabe', 'harms', 'temp', now()); 
+INSERT INTO users (admin, email, company_name, first_name, last_name, password_hash, created_date) VALUES ('t', 'gabeharms', 'Gabe Incorporated', 'gabe', 'harms', 'temp', now()); 

--- a/src/handlers/credit/create.rs
+++ b/src/handlers/credit/create.rs
@@ -25,6 +25,8 @@ impl Handler for Create {
 }
 fn build_new_credit(req: &mut Request) -> Createable {
     let user_id = get_user_id(req);
+    let project_name = get_key_from_body::<String>(req, "projectName");
+    let payment_number = get_key_from_body::<i32>(req, "paymentNumber");
     let amount = get_key_from_body::<i32>(req, "amount");
     let paid_date = from_unix_to_postgres_datetime(
         get_key_from_body::<i64>(req, "paidDate").unwrap()
@@ -33,6 +35,8 @@ fn build_new_credit(req: &mut Request) -> Createable {
 
     Createable {
         user_id: user_id,
+        project_name: project_name.unwrap().replace("\"", ""),
+        payment_number: payment_number.unwrap(),
         amount: amount,
         paid_date: Some(PgTimestamp(paid_date)),
         created_date: created_date

--- a/src/handlers/credit/update.rs
+++ b/src/handlers/credit/update.rs
@@ -25,13 +25,16 @@ impl Handler for Update {
 fn get_params(req: &mut Request) -> (i32, i32, Alterable) {
     let credit_id = get_route_id(req);
     let user_id = get_user_id(req);
-
+    let project_name = get_key_from_body::<String>(req, "projectName");
+    let payment_number = get_key_from_body::<i32>(req, "paymentNumber");
     let amount = get_key_from_body::<i32>(req, "amount");
     let paid_date = from_unix_to_postgres_datetime(
         get_key_from_body::<i64>(req, "paidDate").unwrap()
     );
 
     let updated_credit = Alterable {
+        project_name: project_name.unwrap().replace("\"", ""),
+        payment_number: payment_number.unwrap(),
         amount: amount,
         paid_date: Some(PgTimestamp(paid_date))
     };

--- a/src/handlers/user/create.rs
+++ b/src/handlers/user/create.rs
@@ -24,6 +24,7 @@ impl Handler for Create {
 fn build_new_user(req: &mut Request) -> Createable {
     let admin = get_key_from_body::<bool>(req, "admin");
     let email = get_key_from_body::<String>(req, "email");
+    let company_name = get_key_from_body::<String>(req, "companyName");
     let first_name = get_key_from_body::<String>(req, "firstName");
     let last_name = get_key_from_body::<String>(req, "lastName");
     let password = get_key_from_body::<String>(req,"password").unwrap();
@@ -34,6 +35,7 @@ fn build_new_user(req: &mut Request) -> Createable {
     Createable {
         admin: admin.unwrap(),
         email: email.unwrap().replace("\"", ""),
+        company_name: company_name.unwrap().replace("\"", ""),
         first_name: first_name.unwrap().replace("\"", ""),
         last_name: last_name.unwrap().replace("\"", ""),
         password_hash: password_hash,

--- a/src/models/credit.rs
+++ b/src/models/credit.rs
@@ -14,6 +14,8 @@ use util::Orm;
 pub struct Credit {
     pub id: i32,
     pub user_id: Option<i32>,
+    pub project_name: String,
+    pub payment_number: i32,
     pub amount: Option<i32>,
     pub paid_date: Option<PgTimestamp>,
     pub created_date: PgTimestamp,
@@ -22,12 +24,16 @@ pub struct Credit {
 #[insertable_into(credits)]
 pub struct Createable {
     pub user_id: i32,
+    pub project_name: String,
+    pub payment_number: i32,
     pub amount: Option<i32>,
     pub paid_date: Option<PgTimestamp>,
     pub created_date: PgTimestamp
 }
 
 pub struct Alterable {
+    pub project_name: String,
+    pub payment_number: i32,
     pub amount: Option<i32>,
     pub paid_date: Option<PgTimestamp>,
 }
@@ -37,6 +43,8 @@ impl ToJson for Credit {
         let mut tree = BTreeMap::new();
         tree.insert("id".to_owned(), self.id.to_json());
         tree.insert("userId".to_owned(), self.user_id.to_json());
+        tree.insert("projectName".to_owned(), self.project_name.to_json());
+        tree.insert("payment_number".to_owned(), self.payment_number.to_json());
         tree.insert("amount".to_owned(), self.amount.to_json());
         tree.insert("paidDate".to_owned(), from_postgres_to_unix_datetime(self.paid_date.unwrap_or(PgTimestamp(0)).0).to_json());
         tree.insert("createdDate".to_owned(), from_postgres_to_unix_datetime(self.created_date.0).to_json());
@@ -54,6 +62,8 @@ impl Orm<Credit, Createable, Alterable> for Credit {
             (
                 credits::id,
                 credits::user_id, 
+                credits::project_name,
+                credits::payment_number,
                 credits::amount,
                 credits::paid_date, 
                 credits::created_date
@@ -73,6 +83,8 @@ impl Orm<Credit, Createable, Alterable> for Credit {
             (
                 credits::id,
                 credits::user_id, 
+                credits::project_name,
+                credits::payment_number,
                 credits::amount,
                 credits::paid_date, 
                 credits::created_date
@@ -91,6 +103,8 @@ impl Orm<Credit, Createable, Alterable> for Credit {
         let result = update(query)
             .set(
                 (
+                    credits::project_name.eq(obj.project_name),
+                    credits::payment_number.eq(obj.payment_number),
                     credits::amount.eq(obj.amount),
                     credits::paid_date.eq(obj.paid_date)
                 )

--- a/src/models/credit.rs
+++ b/src/models/credit.rs
@@ -44,7 +44,7 @@ impl ToJson for Credit {
         tree.insert("id".to_owned(), self.id.to_json());
         tree.insert("userId".to_owned(), self.user_id.to_json());
         tree.insert("projectName".to_owned(), self.project_name.to_json());
-        tree.insert("payment_number".to_owned(), self.payment_number.to_json());
+        tree.insert("paymentNumber".to_owned(), self.payment_number.to_json());
         tree.insert("amount".to_owned(), self.amount.to_json());
         tree.insert("paidDate".to_owned(), from_postgres_to_unix_datetime(self.paid_date.unwrap_or(PgTimestamp(0)).0).to_json());
         tree.insert("createdDate".to_owned(), from_postgres_to_unix_datetime(self.created_date.0).to_json());

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -14,6 +14,7 @@ pub struct User {
     pub id: i32,
     pub admin: bool,
     pub email: String,
+    pub company_name: String,
     pub first_name: String,
     pub last_name: String,
     pub password_hash: String,
@@ -25,6 +26,7 @@ pub struct Retrievable {
     pub id: i32,
     pub admin: bool,
     pub email: String,
+    pub company_name: String,
     pub first_name: String,
     pub last_name: String,
     pub created_date: PgTimestamp,
@@ -34,6 +36,7 @@ pub struct Retrievable {
 pub struct Createable {
     pub admin: bool,
     pub email: String,
+    pub company_name: String,
     pub first_name: String,
     pub last_name: String,
     pub password_hash: String,
@@ -42,6 +45,7 @@ pub struct Createable {
 
 pub struct Alterable {
     pub admin: bool,
+    pub company_name: String,
     pub first_name: String,
     pub last_name: String,
     pub password_hash: String
@@ -53,6 +57,7 @@ impl ToJson for User {
         tree.insert("id".to_owned(), self.id.to_json());
         tree.insert("admin".to_owned(), self.admin.to_json());
         tree.insert("email".to_owned(), self.email.to_json());
+        tree.insert("companyName".to_owned(), self.company_name.to_json());
         tree.insert("firstName".to_owned(), self.first_name.to_json());
         tree.insert("lastName".to_owned(), self.last_name.to_json());
         tree.insert("createdDate".to_owned(), from_postgres_to_unix_datetime(self.created_date.0).to_json());
@@ -71,6 +76,7 @@ impl User {
             (
                 users::id,
                 users::admin,
+                users::company_name,
                 users::email,
                 users::first_name,
                 users::last_name,
@@ -89,6 +95,7 @@ impl User {
                 users::id,
                 users::admin,
                 users::email,
+                users::company_name,
                 users::first_name,
                 users::last_name,
                 users::password_hash,
@@ -107,6 +114,7 @@ impl User {
                 users::id,
                 users::admin,
                 users::email,
+                users::company_name,
                 users::first_name,
                 users::last_name,
                 users::password_hash,
@@ -126,6 +134,7 @@ impl User {
             .set(
                 (
                     users::admin.eq(obj.admin),
+                    users::company_name.eq(obj.company_name),
                     users::first_name.eq(obj.first_name),
                     users::last_name.eq(obj.last_name),
                     users::password_hash.eq(obj.password_hash)


### PR DESCRIPTION
### Description
There have been some missing fields from the database and models. We need to be able to support company name, project name and payment number. I have decided that a company would be associated with a user, and a project name and payment number are associated with a credit.

### Changes
- Added new columns to `users` and `credits` tables
- Updated rust `user' and `credit` models in accordance with the new columns
- Updated handlers to be able to parse the new columns
- Updated client side `user` and `client` models
- Added new fields to the `credit` page